### PR TITLE
Fixed npm run build

### DIFF
--- a/ai-chat/vite.config.ts
+++ b/ai-chat/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  root: 'src/client',
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+});

--- a/empty-project/vite.config.ts
+++ b/empty-project/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  root: 'src/client',
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+});


### PR DESCRIPTION
For the following example apps "npm run build" was always failing becuase vite configuration was missing.