### PR TITLE
Data API: Allow passing api-key to every request as a header

### DIFF
--- a/data-api/src/server/data-api/middleware/auth.ts
+++ b/data-api/src/server/data-api/middleware/auth.ts
@@ -1,17 +1,48 @@
 import { RouteParams, RouteResponse } from 'modelence/server';
 import { dataApiTokens } from '../db';
-import { ErrorResponse } from '../utils';
+import { ErrorResponse, validateApiKey } from '../utils';
+import { AuthError, ValidationError } from 'modelence';
 
 export async function authenticateToken(params: RouteParams): Promise<RouteResponse<ErrorResponse> | null> {
   try {
+    // Check for apiKey header first
+    const apiKeyHeader = params.headers.apikey;
+    if (apiKeyHeader) {
+      try {
+        // API Key authentication
+        validateApiKey(apiKeyHeader);
+        // API key is valid, allow request to proceed
+        return null;
+      } catch (error) {
+        if (error instanceof ValidationError) {
+          return {
+            status: error.status,
+            data: {
+              error: error.message,
+              error_code: "InternalServerError"
+            }
+          };
+        } else if (error instanceof AuthError) {
+          return {
+            status: error.status,
+            data: {
+              error: error.message,
+              error_code: "InvalidCredentials"
+            }
+          };
+        }
+        throw error;
+      }
+    }
+
     // Check for Authorization header with Bearer token
     const authHeader = params.headers.authorization;
-    
+
     if (!authHeader) {
       return {
         status: 401,
         data: {
-          error: "Missing Authorization header",
+          error: "Missing Authorization header or apiKey header",
           error_code: "MissingAuthInfo"
         }
       };
@@ -30,7 +61,7 @@ export async function authenticateToken(params: RouteParams): Promise<RouteRespo
 
     // Extract the token
     const token = authHeader.substring(7); // Remove "Bearer " prefix
-    
+
     if (!token) {
       return {
         status: 401,

--- a/data-api/src/server/data-api/providers/api-key/login.ts
+++ b/data-api/src/server/data-api/providers/api-key/login.ts
@@ -1,8 +1,8 @@
 import crypto from 'crypto';
-import { getConfig, RouteParams, RouteResponse } from 'modelence/server';
-import { ErrorResponse } from '../../utils';
+import { AuthError, time, ValidationError } from 'modelence';
+import { RouteParams, RouteResponse } from 'modelence/server';
+import { ErrorResponse, validateApiKey } from '../../utils';
 import { dataApiTokens } from '../../db';
-import { time } from 'modelence';
 
 interface LoginRequest {
   key: string;
@@ -30,43 +30,28 @@ export async function login(params: RouteParams): Promise<RouteResponse<LoginRes
       };
     }
 
-    // Get the configured API key from module config
-    const configuredApiKey = getConfig('dataApi.apiKey') as string || process.env.DATA_API_KEY;
-    
-    if (!configuredApiKey) {
-      return {
-        status: 500,
-        data: {
-          error: "API key authentication not configured",
-          error_code: "InternalServerError"
-        }
-      };
-    }
-
-    // Ensure both keys are converted to buffers with the same encoding
-    const providedKeyBuffer = Buffer.from(key, 'utf8');
-    const configuredKeyBuffer = Buffer.from(configuredApiKey, 'utf8');
-    
-    // Use timing-safe comparison only if buffers have the same length
-    // If they don't match in length, they're definitely not equal
-    if (providedKeyBuffer.length !== configuredKeyBuffer.length) {
-      return {
-        status: 401,
-        data: {
-          error: "Invalid API key",
-          error_code: "InvalidCredentials"
-        }
-      };
-    }
-    
-    if (!crypto.timingSafeEqual(providedKeyBuffer, configuredKeyBuffer)) {
-      return {
-        status: 401,
-        data: {
-          error: "Invalid API key",
-          error_code: "InvalidCredentials"
-        }
-      };
+    // Validate the API key
+    try {
+      validateApiKey(key);
+    } catch (error) {
+      if (error instanceof ValidationError) {
+        return {
+          status: error.status,
+          data: {
+            error: error.message,
+            error_code: "InternalServerError"
+          }
+        };
+      } else if (error instanceof AuthError) {
+        return {
+          status: error.status,
+          data: {
+            error: error.message,
+            error_code: "InvalidCredentials"
+          }
+        };
+      }
+      throw error;
     }
 
     // Generate secure access and refresh tokens

--- a/data-api/src/server/data-api/utils.ts
+++ b/data-api/src/server/data-api/utils.ts
@@ -1,4 +1,7 @@
+import crypto from 'crypto';
 import { ObjectId } from 'mongodb';
+import { ValidationError, AuthError } from 'modelence';
+import { getConfig } from 'modelence/server';
 
 export interface ErrorResponse {
   error: string;
@@ -40,4 +43,21 @@ export function processUpdate(update: Record<string, any>): Record<string, any> 
   }
   
   return processedUpdate;
+}
+
+export function validateApiKey(providedApiKey: string): void {
+  const configuredApiKey = getConfig('dataApi.apiKey') as string || process.env.DATA_API_KEY;
+
+  if (!configuredApiKey) {
+    throw new ValidationError('API key authentication not configured');
+  }
+
+  // Use timing-safe comparison for API key validation
+  const providedKeyBuffer = Buffer.from(providedApiKey, 'utf8');
+  const configuredKeyBuffer = Buffer.from(configuredApiKey, 'utf8');
+
+  if (providedKeyBuffer.length !== configuredKeyBuffer.length ||
+      !crypto.timingSafeEqual(providedKeyBuffer, configuredKeyBuffer)) {
+    throw new AuthError('Invalid API key');
+  }
 }


### PR DESCRIPTION
It's one of the authentication methods of the MongoDB Data Api (Reference https://www.mongodb.com/docs/atlas/app-services/data-api/examples/#find-a-single-document)